### PR TITLE
chore(nx): typecheck tasks depend on dependency library builds

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -81,6 +81,9 @@
   "targetDefaults": {
     "test": {
       "dependsOn": ["^build"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
     }
   }
 }


### PR DESCRIPTION
Typecheck requires that the libries d.ts files are built. This adds the build target for library dependencies as a default task dependency for the typecheck task.